### PR TITLE
[DEV-4046] Also convert arrow functions to basic JS using babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@adyen/threeds2-js-utils": "github:Adyen/adyen-3ds2-js-utils#a5147631210fad888461efe8e52b8e7137930995",
     "@babel/core": "^7.4.3",
+    "@babel/plugin-transform-arrow-functions": "^7.2.0",
     "@babel/plugin-transform-template-literals": "^7.4.4",
     "@babel/preset-env": "^7.4.3",
     "babel-loader": "^8.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,10 @@ module.exports = {
 					options: {
 						compact: true,
 						highlightCode: true,
-						plugins: ["@babel/plugin-transform-template-literals"]
+						plugins: [
+							"@babel/plugin-transform-template-literals",
+							"@babel/plugin-transform-arrow-functions"
+						]
 					}
 				}
 			]


### PR DESCRIPTION
Arrow functions are still dying on IE11